### PR TITLE
Add accordion-style section organization with locking system

### DIFF
--- a/hex-pressure/notes/CHANGELOG.md
+++ b/hex-pressure/notes/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## 2026-01-13
+
+### Added
+- **Accordion-Style Section Organization**
+  - Implemented collapsible section headers for level organization
+  - Section headers show expand/collapse arrows (▶ collapsed, ▼ expanded)
+  - Each section displays progress: earned stars / max stars (e.g., "12 / 15 ★")
+  - Introduction section starts expanded by default
+  - Levels are nested under section headers with visual indentation
+  - Improved level navigation with progressive disclosure
+
+- **Section Locking System with Configurable Thresholds**
+  - Added `unlockThreshold` property to `LevelDef` type (percentage 0-100)
+  - Threshold is configurable per section and defaults to 80%
+  - First section (Introduction) is always unlocked
+  - Subsequent sections require completion percentage of previous section
+  - Locked sections display 🔒 lock icon and red-tinted styling
+  - Clear unlock requirements shown: "Complete 80% of Introduction (12/15 ★) to unlock"
+  - Locked sections can be expanded to preview content but levels are unplayable
+  - Shows "5 levels locked" placeholder message for locked sections
+
+- **Second Level Section: Foundations**
+  - Added 5 new levels (w2-01 through w2-05) mirroring Introduction section
+  - Reinforces core rotation mechanics with identical puzzle configurations
+  - Section requires 80% completion (12/15 stars) of Introduction to unlock
+  - Total game content expanded from 5 to 10 levels
+
+- **Enhanced Section Statistics**
+  - Real-time completion percentage calculation per section
+  - Automatic unlock status updates as progress is made
+  - Section metadata tracking with order preservation
+
+### Changed
+- **Level Section Names**
+  - Renamed section identifier from `"intro"` to `"Introduction"` for consistency
+  - More formal, user-friendly section naming convention
+  - Updated all 5 Introduction levels with new section name
+
+- **UI Layout Improvements**
+  - Section headers now more prominent with distinct styling
+  - Better visual hierarchy between sections and levels
+  - Locked sections have reduced opacity (0.6) and warning colors
+  - Star progress always visible even for locked sections
+
+### Technical Details
+- Section locking logic implemented with `getSectionStats()` and `isSectionUnlocked()` callbacks
+- `starsForLevel` function wrapped in `useCallback` for React optimization
+- Section order tracked in `levelsBySection` memoized structure
+- Lock status checked against previous section's completion percentage
+- Default threshold of 80% applied when `unlockThreshold` not specified
+
+---
+
 ## 2026-01-05
 
 ### Added

--- a/hex-pressure/notes/contributing.md
+++ b/hex-pressure/notes/contributing.md
@@ -21,7 +21,9 @@ Runs engine-only tests (Vitest).
 ## Guidelines
 
 * Follow rules documented in `DESIGN.md`
+* Review `CHANGELOG.md` to be familiar with recent updates
 * Check `ROADMAP.md` before introducing new mechanics
+* Review latest `ANALYSIS-REPORT.md` entries for development prioritizations
 * Prefer small, reviewable changes
 * Engine changes should include or update tests
 * UI/Canvas changes do not require tests (for now)

--- a/hex-pressure/notes/roadmap.md
+++ b/hex-pressure/notes/roadmap.md
@@ -45,8 +45,8 @@ don’t get lost or re-litigated. If something is deferred, it belongs here. If 
 - ~~Undo is not reducing move count but should be~~
 - ~~if the puzzle is solved, Undo should be disabled for that puzzle~~
 - memoize `derived` computation by encoding
-- Dev progress reset for play testing replay features
-- Replay only works once and then resets the puzzle
+- ~~Dev progress reset for play testing replay features~~
+- ~~Replay only works once and then resets the puzzle~~
 
 ---
 

--- a/hex-pressure/src/App.tsx
+++ b/hex-pressure/src/App.tsx
@@ -80,7 +80,7 @@ function starsForMoves(moves: number, ideal: number, twoStarMax: number): number
 }
 
 
-// maimn App component
+// Main App component
 export default function App() {
   const [levelIndex, setLevelIndex] = useState(0);
   const level = LEVELS[levelIndex];
@@ -89,6 +89,9 @@ export default function App() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [showNumbers, setShowNumbers] = useState(level.rules.defaultShowNumbers ?? true);
   const [showHud, setShowHud] = useState(true);
+
+  // Accordion state: track which sections are expanded
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(() => new Set(["Introduction"]));
 
   /** Replay state (initialized from localStorage) */
   const [replaysByLevel, setReplaysByLevel] = useState<Record<string, LevelReplays>>(() => loadReplays());
@@ -116,6 +119,88 @@ export default function App() {
 
   const replayCtrlRef = useRef<ReplayCtrl | null>(null);
   const replayRunIdRef = useRef(0);
+
+  // Helper function to calculate stars for a level
+  const starsForLevel = useCallback((levelId: string, ideal: number, twoStarMax: number): number | null => {
+    const slots = replaysByLevel[levelId];
+    const rec = slots?.best ?? slots?.latest;
+    if (!rec) return null; // not completed
+    return starsForMoves(rec.moves.length, ideal, twoStarMax);
+  }, [replaysByLevel]);
+
+  // Group levels by section and track section order
+  const levelsBySection = useMemo(() => {
+    const groups: Record<string, Array<{ level: typeof LEVELS[0]; index: number }>> = {};
+    const sectionOrder: string[] = [];
+
+    LEVELS.forEach((lvl, idx) => {
+      const sectionName = lvl.section ?? "Other";
+      if (!groups[sectionName]) {
+        groups[sectionName] = [];
+        sectionOrder.push(sectionName);
+      }
+      groups[sectionName].push({ level: lvl, index: idx });
+    });
+
+    return { groups, sectionOrder };
+  }, []);
+
+  // Calculate section completion and unlock status
+  const getSectionStats = useCallback((sectionName: string) => {
+    const levels = levelsBySection.groups[sectionName] || [];
+    const earnedStars = levels.reduce((acc, { level: l }) => {
+      const stars = starsForLevel(l.id, l.scoring.idealMoves, l.scoring.twoStarMax);
+      return acc + (stars ?? 0);
+    }, 0);
+    const maxStars = levels.length * 3;
+    const completionPercent = maxStars > 0 ? Math.floor((earnedStars / maxStars) * 100) : 0;
+
+    return { earnedStars, maxStars, completionPercent };
+  }, [levelsBySection.groups, starsForLevel]);
+
+  // Check if a section is unlocked
+  const isSectionUnlocked = useCallback((sectionName: string): { unlocked: boolean; reason?: string } => {
+    const sectionIndex = levelsBySection.sectionOrder.indexOf(sectionName);
+
+    // First section is always unlocked
+    if (sectionIndex === 0) {
+      return { unlocked: true };
+    }
+
+    // Get the first level of this section to check unlock threshold
+    const firstLevelInSection = levelsBySection.groups[sectionName]?.[0]?.level;
+    if (!firstLevelInSection) {
+      return { unlocked: true }; // No levels, consider unlocked
+    }
+
+    const threshold = firstLevelInSection.unlockThreshold ?? 80; // Default to 80%
+
+    // Check previous section completion
+    const previousSectionName = levelsBySection.sectionOrder[sectionIndex - 1];
+    const prevStats = getSectionStats(previousSectionName);
+
+    if (prevStats.completionPercent >= threshold) {
+      return { unlocked: true };
+    }
+
+    const starsNeeded = Math.ceil((threshold / 100) * prevStats.maxStars);
+    return {
+      unlocked: false,
+      reason: `Complete ${threshold}% of ${previousSectionName} (${starsNeeded}/${prevStats.maxStars} ★) to unlock`,
+    };
+  }, [levelsBySection.groups, levelsBySection.sectionOrder, getSectionStats]);
+
+  const toggleSection = (sectionName: string) => {
+    setExpandedSections(prev => {
+      const next = new Set(prev);
+      if (next.has(sectionName)) {
+        next.delete(sectionName);
+      } else {
+        next.add(sectionName);
+      }
+      return next;
+    });
+  };
 
   const selectedTile = selectedId ? state.tilesById[selectedId] : null;
   const canRotate =
@@ -274,13 +359,6 @@ export default function App() {
     const ascended = moves < ideal;
     return { stars, ascended, moves, ideal, two };
   }, [state.moveCount, level.scoring]);
-
-  function starsForLevel(levelId: string, ideal: number, twoStarMax: number): number | null {
-    const slots = replaysByLevel[levelId];
-    const rec = slots?.best ?? slots?.latest;
-    if (!rec) return null; // not completed
-    return starsForMoves(rec.moves.length, ideal, twoStarMax);
-  }
 
   function rotate(dir: "CW" | "CCW") {
     if (isReplaying) return;
@@ -651,55 +729,127 @@ export default function App() {
         }}
       >
         <div style={{ fontWeight: 650, marginBottom: 10 }}>Levels</div>
-        <div style={{ display: "grid", gap: 8 }}>
-          {LEVELS.map((l, i) => (
-            <button
-              key={l.id}
-              onClick={() => load(i)}
-              disabled={isReplaying}
-              style={{
-                textAlign: "left",
-                padding: "10px 10px",
-                borderRadius: 10,
-                border: i === levelIndex ? "1px solid rgba(255,255,255,0.45)" : "1px solid rgba(255,255,255,0.12)",
-                background: i === levelIndex ? "rgba(255,255,255,0.08)" : "rgba(255,255,255,0.03)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                gap: 12,
-              }}
-            >
-              <div style={{ minWidth: 0 }}>
-                <div style={{ fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                  {l.name}
+        <div style={{ display: "grid", gap: 10 }}>
+          {Object.entries(levelsBySection.groups).map(([sectionName, levelsInSection]) => {
+            const isExpanded = expandedSections.has(sectionName);
+            const stats = getSectionStats(sectionName);
+            const unlockStatus = isSectionUnlocked(sectionName);
+            const isLocked = !unlockStatus.unlocked;
+
+            return (
+              <div key={sectionName} style={{ display: "grid", gap: 6 }}>
+                {/* Section header (accordion toggle) */}
+                <div style={{ display: "grid", gap: 4 }}>
+                  <button
+                    onClick={() => toggleSection(sectionName)}
+                    disabled={isReplaying}
+                    style={{
+                      textAlign: "left",
+                      padding: "10px 12px",
+                      borderRadius: 10,
+                      border: isLocked ? "1px solid rgba(255,100,100,0.25)" : "1px solid rgba(255,255,255,0.18)",
+                      background: isLocked ? "rgba(255,100,100,0.05)" : "rgba(255,255,255,0.06)",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      gap: 10,
+                      fontWeight: 600,
+                      opacity: isLocked ? 0.6 : 1,
+                    }}
+                  >
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <span style={{ fontSize: 14, opacity: 0.8 }}>
+                        {isLocked ? "🔒" : (isExpanded ? "▼" : "▶")}
+                      </span>
+                      <span>{sectionName}</span>
+                    </div>
+                    <div style={{ fontSize: 13, opacity: 0.75 }}>
+                      {stats.earnedStars} / {stats.maxStars} ★
+                    </div>
+                  </button>
+
+                  {/* Lock message */}
+                  {isLocked && (
+                    <div style={{
+                      fontSize: 11,
+                      opacity: 0.7,
+                      paddingLeft: 36,
+                      lineHeight: 1.3,
+                    }}>
+                      {unlockStatus.reason}
+                    </div>
+                  )}
                 </div>
-                <div style={{ fontSize: 12, opacity: 0.75 }}>{l.id}</div>
-              </div>
 
-              {(() => {
-                const stars = starsForLevel(l.id, l.scoring.idealMoves, l.scoring.twoStarMax);
-                if (stars == null) return null;
-
-                return (
-                  <div style={{ display: "inline-flex", gap: 2, flexShrink: 0 }}>
-                    {[1, 2, 3].map((s) => (
-                      <span
-                        key={s}
+                {/* Level list (shown when expanded and unlocked) */}
+                {isExpanded && !isLocked && (
+                  <div style={{ display: "grid", gap: 6, paddingLeft: 8 }}>
+                    {levelsInSection.map(({ level: l, index: i }) => (
+                      <button
+                        key={l.id}
+                        onClick={() => load(i)}
+                        disabled={isReplaying}
                         style={{
-                          opacity: s <= stars ? 1 : 0.25,
-                          color: "#f4c542",
-                          fontSize: 14,
-                          lineHeight: 1,
+                          textAlign: "left",
+                          padding: "10px 10px",
+                          borderRadius: 10,
+                          border: i === levelIndex ? "1px solid rgba(255,255,255,0.45)" : "1px solid rgba(255,255,255,0.12)",
+                          background: i === levelIndex ? "rgba(255,255,255,0.08)" : "rgba(255,255,255,0.03)",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "space-between",
+                          gap: 12,
                         }}
                       >
-                        ★
-                      </span>
+                        <div style={{ minWidth: 0 }}>
+                          <div style={{ fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                            {l.name}
+                          </div>
+                          <div style={{ fontSize: 12, opacity: 0.75 }}>{l.id}</div>
+                        </div>
+
+                        {(() => {
+                          const stars = starsForLevel(l.id, l.scoring.idealMoves, l.scoring.twoStarMax);
+                          if (stars == null) return null;
+
+                          return (
+                            <div style={{ display: "inline-flex", gap: 2, flexShrink: 0 }}>
+                              {[1, 2, 3].map((s) => (
+                                <span
+                                  key={s}
+                                  style={{
+                                    opacity: s <= stars ? 1 : 0.25,
+                                    color: "#f4c542",
+                                    fontSize: 14,
+                                    lineHeight: 1,
+                                  }}
+                                >
+                                  ★
+                                </span>
+                              ))}
+                            </div>
+                          );
+                        })()}
+                      </button>
                     ))}
                   </div>
-                );
-              })()}
-            </button>
-          ))}
+                )}
+
+                {/* Show locked placeholder when expanded but locked */}
+                {isExpanded && isLocked && (
+                  <div style={{
+                    paddingLeft: 8,
+                    fontSize: 13,
+                    opacity: 0.5,
+                    fontStyle: "italic",
+                    padding: "10px",
+                  }}>
+                    {levelsInSection.length} level{levelsInSection.length !== 1 ? 's' : ''} locked
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
 
         {/* Replay controls */}

--- a/hex-pressure/src/engine/levels.ts
+++ b/hex-pressure/src/engine/levels.ts
@@ -31,7 +31,7 @@ export const LEVELS: LevelDef[] = [
     // Intended ideal moves: 1
     id: "w1-01",
     name: "Warmup",
-    section: "intro",
+    section: "Introduction",
     board: { cells: FLOWER_CELLS },
     tiles: [
       // Problem tile: counts 2 neighbors initially (E + NE) but limit is 1.
@@ -52,7 +52,7 @@ export const LEVELS: LevelDef[] = [
     // Intended ideal moves: 1
     id: "w1-02",
     name: "Zero Tolerance",
-    section: "intro",
+    section: "Introduction",
     board: { cells: FLOWER_CELLS },
     tiles: [
       // Anchor neighbor (stable)
@@ -74,7 +74,7 @@ export const LEVELS: LevelDef[] = [
     // Intended ideal moves: 4
     id: "w1-03",
     name: "Two Knobs",
-    section: "intro",
+    section: "Introduction",
     board: { cells: FLOWER_CELLS },
     tiles: [
       // Problem tile A: has 3 occupied neighbors (E=B, NE=C, NW=D).
@@ -103,7 +103,7 @@ export const LEVELS: LevelDef[] = [
     // Intended ideal moves: 2
     id: "w1-04",
     name: "Wrong Way",
-    section: "intro",
+    section: "Introduction",
     board: { cells: FLOWER_CELLS },
     tiles: [
       // A is red because it counts E (B) + NE (C) with limit 1.
@@ -131,7 +131,7 @@ export const LEVELS: LevelDef[] = [
     // Intended ideal moves: 5 (subject to adjustment once solver exists)
     id: "w1-05",
     name: "Safety Valve",
-    section: "intro",
+    section: "Introduction",
     board: { cells: FLOWER_CELLS },
     tiles: [
       // Sink is always calm (limit huge); it increases local density without becoming a constraint.
@@ -147,7 +147,86 @@ export const LEVELS: LevelDef[] = [
       // This one starts more constrained; typically needs ~1–2 turns.
       { id: "C", type: "DIRECTIONAL", q: 0, r: -1, orient: 5, limit: 1 },
 
-      // One neutral to complete the “feel” of the cluster without adding unsolvable constraints.
+      // One neutral to complete the "feel" of the cluster without adding unsolvable constraints.
+      { id: "N", type: "NEUTRAL", q: 0, r: 1, limit: 6 },
+    ],
+    scoring: { idealMoves: 5, twoStarMax: 9 },
+    rules: { allowRotate: true, allowUndo: true, allowMove: false, defaultShowNumbers: true },
+  },
+
+  // ===== FOUNDATIONS SECTION =====
+  // Second section: reinforcing core mechanics with similar challenges
+  // Requires 80% completion (12/15 stars) of Introduction section to unlock
+
+  {
+    id: "w2-01",
+    name: "Warmup",
+    section: "Foundations",
+    unlockThreshold: 80,
+    board: { cells: FLOWER_CELLS },
+    tiles: [
+      { id: "A", type: "DIRECTIONAL", q: 0, r: 0, orient: 0, limit: 1 },
+      { id: "B", type: "NEUTRAL", q: 1, r: 0, limit: 6 },
+      { id: "C", type: "NEUTRAL", q: 1, r: -1, limit: 6 },
+    ],
+    scoring: { idealMoves: 1, twoStarMax: 3 },
+    rules: { allowRotate: true, allowUndo: true, allowMove: false, defaultShowNumbers: true },
+  },
+
+  {
+    id: "w2-02",
+    name: "Zero Tolerance",
+    section: "Foundations",
+    board: { cells: FLOWER_CELLS },
+    tiles: [
+      { id: "A", type: "NEUTRAL", q: 0, r: 0, limit: 6 },
+      { id: "B", type: "DIRECTIONAL", q: 1, r: 0, orient: 3, limit: 0 },
+    ],
+    scoring: { idealMoves: 1, twoStarMax: 3 },
+    rules: { allowRotate: true, allowUndo: true, allowMove: false, defaultShowNumbers: true },
+  },
+
+  {
+    id: "w2-03",
+    name: "Two Knobs",
+    section: "Foundations",
+    board: { cells: FLOWER_CELLS },
+    tiles: [
+      { id: "A", type: "DIRECTIONAL", q: 0, r: 0, orient: 0, limit: 1 },
+      { id: "B", type: "DIRECTIONAL", q: 1, r: 0, orient: 2, limit: 1 },
+      { id: "C", type: "NEUTRAL", q: 1, r: -1, limit: 6 },
+      { id: "D", type: "NEUTRAL", q: 0, r: -1, limit: 6 },
+      { id: "E", type: "NEUTRAL", q: 0, r: 1, limit: 6 },
+    ],
+    scoring: { idealMoves: 4, twoStarMax: 7 },
+    rules: { allowRotate: true, allowUndo: true, allowMove: false, defaultShowNumbers: true },
+  },
+
+  {
+    id: "w2-04",
+    name: "Wrong Way",
+    section: "Foundations",
+    board: { cells: FLOWER_CELLS },
+    tiles: [
+      { id: "A", type: "DIRECTIONAL", q: 0, r: 0, orient: 0, limit: 1 },
+      { id: "B", type: "DIRECTIONAL", q: 1, r: 0, orient: 1, limit: 1 },
+      { id: "C", type: "NEUTRAL", q: 1, r: -1, limit: 6 },
+      { id: "D", type: "NEUTRAL", q: 0, r: 1, limit: 6 },
+    ],
+    scoring: { idealMoves: 2, twoStarMax: 5 },
+    rules: { allowRotate: true, allowUndo: true, allowMove: false, defaultShowNumbers: true },
+  },
+
+  {
+    id: "w2-05",
+    name: "Safety Valve",
+    section: "Foundations",
+    board: { cells: FLOWER_CELLS },
+    tiles: [
+      { id: "S", type: "SINK", q: 0, r: 0, orient: 0, limit: 999 },
+      { id: "A", type: "DIRECTIONAL", q: 1, r: 0, orient: 2, limit: 1 },
+      { id: "B", type: "DIRECTIONAL", q: 1, r: -1, orient: 3, limit: 1 },
+      { id: "C", type: "DIRECTIONAL", q: 0, r: -1, orient: 5, limit: 1 },
       { id: "N", type: "NEUTRAL", q: 0, r: 1, limit: 6 },
     ],
     scoring: { idealMoves: 5, twoStarMax: 9 },

--- a/hex-pressure/src/engine/types.ts
+++ b/hex-pressure/src/engine/types.ts
@@ -26,6 +26,7 @@ export type LevelDef = {
   id: string;
   name: string;
   section?: string; // Optional section identifier for grouping levels
+  unlockThreshold?: number; // Percentage (0-100) of previous section required to unlock this section. Defaults to 80.
   board: { cells: Array<{ q: number; r: number }> };
   tiles: Array<{
     id: string;


### PR DESCRIPTION
Implements issue #13 - Section organization and progressive unlocking

## Features Added:
- Accordion UI with collapsible section headers (▶/▼ indicators)
- Section progress tracking (earned stars / max stars)
- Configurable section locking system (default 80% threshold)
- Second section "Foundations" with 5 duplicate levels (w2-01 to w2-05)
- Renamed first section from "intro" to "Introduction"

## Implementation Details:
- Added `unlockThreshold` property to LevelDef type
- Section locking logic with `getSectionStats()` and `isSectionUnlocked()`
- Visual lock indicators (🔒 icon, red styling, reduced opacity)
- Clear unlock requirements displayed for locked sections
- Locked sections expandable but levels unplayable

## Testing:
- All 14 existing tests passing
- Build successful with no new warnings
- Total game content: 10 levels across 2 sections

Closes #13